### PR TITLE
Citing correctly

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -135,6 +135,12 @@
         for historical reasons, but it will be taken down eventually.
         It contains an older, pre-release edition of the specification and documentation entries that are now obsolete.
     </p>
+    <p>
+        Please <a
+            href="https://forum.uavcan.org/t/referencing-the-uavcan-project-in-publications/766"
+            target="_blank"
+        >reference UAVCAN in scientific or technical publications</a>.
+    </p>
 
 {% set fallback_image = '/static/images/logo-square.svg' %}
 {% if forum_feed_entries %}


### PR DESCRIPTION
This is a response to my observation that even recently published papers provide an incorrect explanation for the acronym "UAVCAN".