### PR TITLE
Switch the frontpage to v1

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -97,6 +97,19 @@ ul {
 li {
     padding-bottom: 0.25em;
 }
+div.scroll-x {
+    overflow-x: auto;
+}
+table.reference {
+    border-collapse: collapse;
+    white-space: nowrap;
+}
+table.reference thead td {
+    border-bottom: #888 solid 1px;
+}
+table.reference td {
+    padding: 0.25em;
+}
 table.feed {
     border-spacing: 0;  /* this is necessary to remove phantom padding */
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -100,21 +100,49 @@
     <p>
         Pick one of the free open source implementations (MIT licensed) for use in your application:
     </p>
-    <ul>
-        <li>
-            <a href="https://github.com/UAVCAN/libuavcan">Libuavcan</a> &mdash;
-            full-featured, highly robust implementation in C++11 for embedded systems and GNU/Linux.
-        </li>
-        <li>
-            <a href="https://github.com/UAVCAN/libcanard">Libcanard</a> &mdash;
-            lightweight implementation in C99 for deeply embedded systems.
-        </li>
-        <li>
-            <a href="https://github.com/UAVCAN/pyuavcan">Pyuavcan</a> &mdash;
-            general-purpose, easy to use Python implementation for high-level operating systems
-            (Windows, GNU/Linux, macOS, etc.).
-        </li>
-    </ul>
+    <div class="scroll-x">
+        <table class="reference">
+            <thead>
+            <tr>
+                <td>Name</td>
+                <td>Transports</td>
+                <td>Language</td>
+                <td>Applications</td>
+                <td>Status</td>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td><a href="https://github.com/UAVCAN/libcanard">Libcanard</a></td>
+                <td>UAVCAN/CAN</td>
+                <td>C11</td>
+                <td>Embedded</td>
+                <td>Released</td>
+            </tr>
+            <tr>
+                <td><a href="https://github.com/UAVCAN/pyuavcan">Pyuavcan</a></td>
+                <td>Any</td>
+                <td>Python</td>
+                <td>HMI</td>
+                <td>Released</td>
+            </tr>
+            <tr>
+                <td><a href="https://github.com/UAVCAN/libuavcan">Libuavcan</a></td>
+                <td>Any</td>
+                <td>C++11</td>
+                <td>Embedded</td>
+                <td>Work-in-progress</td>
+            </tr>
+            <tr>
+                <td><a href="https://github.com/UAVCAN/uavcan.rs">uavcan.rs</a></td>
+                <td>Any</td>
+                <td>Rust</td>
+                <td>Embedded</td>
+                <td>Work-in-progress</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
     <p>
         None of the implementations suit your needs? Write your own!
         UAVCAN is a very simple protocol; an experienced developer can easily create a custom implementation
@@ -125,8 +153,13 @@
     </p>
     <ul>
         <li>
-            <a href="https://github.com/UAVCAN/Yukon">Yukon</a> &mdash;
+            <a href="https://github.com/UAVCAN/Yukon">Yukon</a> <em>(work-in-progress)</em> &mdash;
             a web-based GUI tool for observing, debugging, and interacting with a UAVCAN bus.
+            This product is currently under active development; ETA 2020Q4.
+        </li>
+        <li>
+            <a href="https://github.com/UAVCAN/nunavut">Nunavut</a> &mdash;
+            a Python library and a CLI tool for generating code from DSDL definitions.
         </li>
         <li>
             <a href="https://github.com/UAVCAN/pydsdl">PyDSDL</a> &mdash;
@@ -134,15 +167,10 @@
         </li>
     </ul>
     <p>
-        The <a href="http://uavcan.github.io/">old version of the website</a> is still available
-        for historical reasons, but it will be taken down eventually.
-        It contains an older, pre-release edition of the specification and documentation entries that are now obsolete.
-    </p>
-    <p>
         Please <a
             href="https://forum.uavcan.org/t/referencing-the-uavcan-project-in-publications/766"
             target="_blank"
-        >reference UAVCAN in scientific or technical publications</a>.
+        >reference UAVCAN</a> in scientific or technical publications.
     </p>
 
 {% set fallback_image = '/static/images/logo-square.svg' %}


### PR DESCRIPTION
After this PR and https://github.com/UAVCAN/libcanard/pull/142 are merged, I am going to update the DNS records to make uavcan.org point to the new website, and make new.uavcan.org redirect to uavcan.org. The old website will continue to be available under uavcan.github.io for a very long period of time.

Existing links published on the Internet will retain validity through legacy redirects.

The change is possible now because, with Libcanard and PyUAVCAN available, v1 is practically usable, despite the lack of a GUI tool.

![image](https://user-images.githubusercontent.com/3298404/75739733-5c702480-5d0e-11ea-9766-af87913aa979.png)
