### PR TITLE
Change deployment path from uavcan.org to opencyphal.org

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SOURCE_DIR: ".,!.git,!.github"
-      TARGET_DIR: "/var/www/uavcan.org"
+      TARGET_DIR: "/var/www/opencyphal.org"
 
     steps:
     - name: Retrieve repository

--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SOURCE_DIR: ".,!.git,!.github"
-      TARGET_DIR: "/var/www/uat.uavcan.org"
+      TARGET_DIR: "/var/www/uat.opencyphal.org"
 
     steps:
     - name: Retrieve repository


### PR DESCRIPTION
This change amends the GH Actions script to deploy website changes to the new web opencyphal.org directory on the web server.